### PR TITLE
Various fixes on container

### DIFF
--- a/cdk_cowrie_honeypots/cdk_cowrie_honeypots_stack.py
+++ b/cdk_cowrie_honeypots/cdk_cowrie_honeypots_stack.py
@@ -6,7 +6,6 @@ from aws_cdk import (
     aws_logs as logs
 )
 
-
 class CdkCowrieHoneypotsStack(core.Stack):
 
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
@@ -22,14 +21,14 @@ class CdkCowrieHoneypotsStack(core.Stack):
         task_definition = ecs.FargateTaskDefinition(self, "HoneypotTasks", cpu=256, memory_limit_mib=512)
 
         # Container definition
-        
         container_definition = ecs.ContainerDefinition(self, "HoneypotContainerDefinition",
-            image=ecs.ContainerImage.from_registry("statixs/cowrie"), 
-            #image=ecs.ContainerImage.from_asset(directory = "docker"),
+            #image=ecs.ContainerImage.from_registry("statixs/cowrie"), 
+            image=ecs.ContainerImage.from_asset(directory = "docker"),
             task_definition=task_definition,
+            stop_timeout=core.Duration.seconds(2),
             logging=ecs.AwsLogDriver(
                 stream_prefix="cowrie",
-                log_retention=logs.RetentionDays.ONE_DAY,
+                log_retention=logs.RetentionDays.ONE_WEEK,
             ),
         )
 
@@ -42,5 +41,6 @@ class CdkCowrieHoneypotsStack(core.Stack):
             assign_public_ip=True, 
             desired_count=1, 
             security_group=sg_ssh, 
-            task_definition=task_definition
+            task_definition=task_definition,
+            platform_version=ecs.FargatePlatformVersion.VERSION1_3
         )

--- a/cdk_cowrie_honeypots/cdk_cowrie_honeypots_stack.py
+++ b/cdk_cowrie_honeypots/cdk_cowrie_honeypots_stack.py
@@ -22,8 +22,8 @@ class CdkCowrieHoneypotsStack(core.Stack):
 
         # Container definition
         container_definition = ecs.ContainerDefinition(self, "HoneypotContainerDefinition",
-            #image=ecs.ContainerImage.from_registry("statixs/cowrie"), 
-            image=ecs.ContainerImage.from_asset(directory = "docker"),
+            image=ecs.ContainerImage.from_registry("statixs/cowrie"), 
+            #image=ecs.ContainerImage.from_asset(directory = "docker"),
             task_definition=task_definition,
             stop_timeout=core.Duration.seconds(2),
             logging=ecs.AwsLogDriver(

--- a/cdk_cowrie_honeypots/cdk_cowrie_honeypots_stack.py
+++ b/cdk_cowrie_honeypots/cdk_cowrie_honeypots_stack.py
@@ -11,8 +11,8 @@ class CdkCowrieHoneypotsStack(core.Stack):
     def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
-        # Create the VPC for the honeypot(s)
-        vpc = ec2.Vpc(self, "HoneypotVpc", max_azs=3)     # default is all AZs in region
+        # Create the VPC for the honeypot(s), default is all AZs in region
+        vpc = ec2.Vpc(self, "HoneypotVpc", max_azs=3)
 
         # Create the ECS cluster where fargate can deploy the Docker containers
         cluster = ecs.Cluster(self, "HoneypotCluster", vpc=vpc) 
@@ -42,5 +42,5 @@ class CdkCowrieHoneypotsStack(core.Stack):
             desired_count=1, 
             security_group=sg_ssh, 
             task_definition=task_definition,
-            platform_version=ecs.FargatePlatformVersion.VERSION1_3
+            platform_version=ecs.FargatePlatformVersion.VERSION1_4
         )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-#FROM debian:bullseye-slim as builder
+# Docker build for Cowrie container that exposes port 22
+# Heavily nspired by the 'docker-cowrie' container file created by Michiel Oosterhof; https://github.com/cowrie/docker-cowrie
+
 FROM ubuntu:latest as builder
 
 ENV COWRIE_GROUP=cowrie \
@@ -17,7 +19,6 @@ RUN groupadd -r -g 1000 ${COWRIE_GROUP} && \
 RUN export DEBIAN_FRONTEND=noninteractive; \
     apt-get update && \
     apt-get dist-upgrade -y  && \
-
     apt-get install -y \
         -o APT::Install-Suggests=false \
         -o APT::Install-Recommends=false \
@@ -52,7 +53,6 @@ RUN git clone --separate-git-dir=/tmp/cowrie.git https://github.com/cowrie/cowri
 
 
 FROM ubuntu:latest as runtime
-#FROM debian:bullseye-slim AS runtime
 
 ENV COWRIE_GROUP=cowrie \
     COWRIE_USER=cowrie \
@@ -63,6 +63,7 @@ RUN groupadd -r -g 1000 ${COWRIE_GROUP} && \
 
 RUN export DEBIAN_FRONTEND=noninteractive; \
     apt-get update && \
+    apt-get dist-upgrade -y && \
     apt-get install -y \
         -o APT::Install-Suggests=false \
         -o APT::Install-Recommends=false \
@@ -72,7 +73,9 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
       authbind \
       python3 && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/bin/python3 /usr/local/bin/python
+    ln -s /usr/bin/python3 /usr/local/bin/python && \
+    apt-get autoremove -y && \
+    apt-get autoclean -y
 
 COPY --from=builder ${COWRIE_HOME} ${COWRIE_HOME}
 RUN chown -R ${COWRIE_USER}:${COWRIE_GROUP} ${COWRIE_HOME}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,5 @@
-# This Dockerfile contains two images, `builder` and `runtime`.
-# `builder` contains all necessary code to build
-# `runtime` is stripped down.
-
-FROM debian:buster-slim as builder
-LABEL maintainer="Michel Oosterhof <michel@oosterhof.net>"
+#FROM debian:bullseye-slim as builder
+FROM ubuntu:latest as builder
 
 ENV COWRIE_GROUP=cowrie \
     COWRIE_USER=cowrie \
@@ -20,6 +16,8 @@ RUN groupadd -r -g 1000 ${COWRIE_GROUP} && \
 # Set up Debian prereqs
 RUN export DEBIAN_FRONTEND=noninteractive; \
     apt-get update && \
+    apt-get dist-upgrade -y  && \
+
     apt-get install -y \
         -o APT::Install-Suggests=false \
         -o APT::Install-Recommends=false \
@@ -35,10 +33,11 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
       python3-virtualenv \
       libsnappy-dev \
       default-libmysqlclient-dev && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y && \
+    apt-get autoclean -y
 
 # Build a cowrie environment from github master HEAD.
-
 USER ${COWRIE_USER}
 
 RUN git clone --separate-git-dir=/tmp/cowrie.git https://github.com/cowrie/cowrie ${COWRIE_HOME}/cowrie-git && \
@@ -51,8 +50,9 @@ RUN git clone --separate-git-dir=/tmp/cowrie.git https://github.com/cowrie/cowri
       pip install --no-cache-dir --upgrade -r ${COWRIE_HOME}/cowrie-git/requirements.txt && \
       pip install --no-cache-dir --upgrade -r ${COWRIE_HOME}/cowrie-git/requirements-output.txt
 
-FROM debian:buster-slim AS runtime
-LABEL maintainer="Michel Oosterhof <michel@oosterhof.net>"
+
+FROM ubuntu:latest as runtime
+#FROM debian:bullseye-slim AS runtime
 
 ENV COWRIE_GROUP=cowrie \
     COWRIE_USER=cowrie \
@@ -67,7 +67,7 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
         -o APT::Install-Suggests=false \
         -o APT::Install-Recommends=false \
       libssl1.1 \
-      libffi6 \
+      libffi7 \
       procps \
       authbind \
       python3 && \
@@ -86,14 +86,9 @@ RUN touch /etc/authbind/byport/22 && chown cowrie /etc/authbind/byport/22 && chm
 USER ${COWRIE_USER}
 WORKDIR ${COWRIE_HOME}/cowrie-git
 
-# preserve .dist file when etc/ volume is mounted
-# RUN cp ${COWRIE_HOME}/cowrie-git/etc/cowrie.cfg.dist ${COWRIE_HOME}/cowrie-git
-# VOLUME [ "/cowrie/cowrie-git/var", "/cowrie/cowrie-git/etc" ]
-# RUN mv ${COWRIE_HOME}/cowrie-git/cowrie.cfg.dist ${COWRIE_HOME}/cowrie-git/etc
-
+# change daemon port to 22
 RUN cat ${COWRIE_HOME}/cowrie-git/etc/cowrie.cfg.dist | sed 's/2222/22/g' > ${COWRIE_HOME}/cowrie-git/etc/cowrie.cfg
 
 ENTRYPOINT [ "cowrie" ]
 CMD [ "start", "-n" ]
 EXPOSE 22
-


### PR DESCRIPTION
- Switched from Debian to Ubuntu as container OS (Debian ~413 MB vs Ubuntu ~119 MB, speeds up booting)
- Included 'dist-upgrade' to fix vulnerable packages
- Switched to Fargate platform version 1.4 (which uses containerd)
- Decreased container stop duration to 2s

Note - I've left the Dockerhub container as the source for the template, you can easily switch it to a local Docker build though. 